### PR TITLE
Fix SEO canonicals, timer leak, and polish pass

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -21,7 +21,7 @@ export type BlogPost = {
   tag_list?: string[];
 };
 
-const REPOS_URL = "https://api.github.com/users/starkblaze01/repos?per_page=200";
+const REPOS_URL = "https://api.github.com/users/starkblaze01/repos?per_page=100";
 const BLOGS_URL = "/api/blogs";
 
 export async function fetchAllRepos(): Promise<Repo[]> {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -25,7 +25,7 @@ export default function Layout() {
         Skip to content
       </a>
 
-      <header className="border-b border-white/5 bg-ink/85 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-white/5 bg-ink/85 backdrop-blur">
         <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
           <NavLink to="/" className="font-mono text-sm tracking-tight">
             <span className="text-red-pokeball">●</span>{" "}
@@ -76,7 +76,7 @@ export default function Layout() {
             </a>{" "}
             · Dubai, UAE
           </p>
-          <p className="mt-1 text-[0.7rem] text-off/40">
+          <p className="mt-1 hidden text-[0.7rem] text-off/40 [@media(hover:hover)]:block">
             Try <span className="kbd">↑ ↑ ↓ ↓ ← → ← → B A</span>
           </p>
         </div>

--- a/src/components/Pokedex.tsx
+++ b/src/components/Pokedex.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useKonami } from "../hooks/useKonami";
 
 const STATS = [
@@ -21,14 +21,23 @@ const META = [
 
 export default function Pokedex() {
   const [open, setOpen] = useState(false);
-  useKonami(() => setOpen((v) => !v));
+  const closeRef = useRef<HTMLButtonElement>(null);
+  useKonami(useCallback(() => setOpen((v) => !v), []));
 
   useEffect(() => {
+    if (!open) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") setOpen(false);
     }
-    if (open) window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    const previous = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+      previous?.focus();
+    };
   }, [open]);
 
   if (!open) return null;
@@ -53,6 +62,7 @@ export default function Pokedex() {
             </h2>
           </div>
           <button
+            ref={closeRef}
             type="button"
             onClick={() => setOpen(false)}
             className="font-mono text-xs text-off/60 hover:text-red-pokeball"

--- a/src/hooks/useDocumentHead.ts
+++ b/src/hooks/useDocumentHead.ts
@@ -35,7 +35,7 @@ const ROUTES: Record<string, Meta> = {
   "/timeline": {
     title: `Timeline${SUFFIX}`,
     description:
-      "What I've shipped on this site since 2019, kept as a log rather than deleted.",
+      "What I've shipped on this site since 2018, kept as a log rather than deleted.",
   },
 };
 
@@ -49,16 +49,30 @@ function setMeta(name: string, content: string, attr: "name" | "property" = "nam
   el.setAttribute("content", content);
 }
 
+function setCanonical(url: string) {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", url);
+}
+
 export function useDocumentHead(override?: Partial<Meta>) {
   const { pathname } = useLocation();
   useEffect(() => {
     const base = ROUTES[pathname] ?? ROUTES["/"];
     const meta = { ...base, ...override };
+    const url = `https://starkblaze01.dev${ROUTES[pathname] && pathname !== "/" ? pathname : "/"}`;
     document.title = meta.title;
     setMeta("description", meta.description);
     setMeta("og:title", meta.title, "property");
     setMeta("og:description", meta.description, "property");
+    setMeta("og:url", url, "property");
     setMeta("twitter:title", meta.title);
     setMeta("twitter:description", meta.description);
+    setMeta("twitter:url", url, "property");
+    setCanonical(url);
   }, [pathname, override?.title, override?.description]);
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -15,6 +15,9 @@ export function useTheme() {
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
     window.localStorage.setItem(KEY, theme);
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", theme === "dark" ? "#0a0a0f" : "#f8f4e9");
   }, [theme]);
 
   return {

--- a/src/hooks/useTyped.ts
+++ b/src/hooks/useTyped.ts
@@ -11,14 +11,18 @@ export function useTyped(text: string, speedMs = 90, startDelayMs = 200) {
     }
     setOut("");
     let i = 0;
+    let interval: number | undefined;
     const start = window.setTimeout(() => {
-      const id = window.setInterval(() => {
+      interval = window.setInterval(() => {
         i += 1;
         setOut(text.slice(0, i));
-        if (i >= text.length) window.clearInterval(id);
+        if (i >= text.length) window.clearInterval(interval);
       }, speedMs);
     }, startDelayMs);
-    return () => window.clearTimeout(start);
+    return () => {
+      window.clearTimeout(start);
+      window.clearInterval(interval);
+    };
   }, [text, speedMs, startDelayMs]);
 
   return out;

--- a/src/index.css
+++ b/src/index.css
@@ -120,7 +120,9 @@
 .cursor {
   display: inline-block;
   width: 0.55ch;
+  height: 0.9em;
   margin-left: 0.1ch;
+  vertical-align: -0.05em;
   background: currentColor;
   animation: cursor-blink 1s steps(1) infinite;
 }

--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -50,8 +50,8 @@ export default function Timeline() {
           Timeline
         </h1>
         <p className="mt-3 text-off/75">
-          What I&rsquo;ve shipped on this site, in order. Old versions aren&rsquo;t
-          deleted — they&rsquo;re tagged.
+          What I&rsquo;ve shipped on this site, in order — a changelog going back
+          to the first build.
         </p>
       </header>
 


### PR DESCRIPTION
- Per-route canonical + og:url/twitter:url (all pages canonicalized to home)
- Clear useTyped interval on unmount; give .cursor real height
- Sync theme-color meta with theme toggle
- Sticky header (backdrop-blur was inert without it)
- Pokedex modal: focus management + scroll lock; stable Konami callback
- Hide Konami hint on touch devices
- Timeline copy: changelog wording, meta says 2018
- GitHub per_page 200 -> 100 (API caps at 100)